### PR TITLE
Bugfixes: updating save link, warning on no clips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mass-aliasing-react",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,11 +40,10 @@ const speedupFactorDefault = 60;
 const speedupErrorColor = "#f88";
 const speedupGoodColor = "#fff"
 
-let outputClip;
-
 function App() {
   const [files, setFiles] = useState([]);
   const [clipsMessage, setClipsMessage] = useState(clipsMessageDefault);
+  const [outputClip, setOutputClip] = useState(null);
   const [outputClipReady, setOutputClipReady] = useState(false);
   const [speedupFactor, setSpeedupFactor] = useState(speedupFactorDefault);
   const [speedupFactorIsValid, setSpeedupFactorIsValid] = useState(true);
@@ -111,11 +110,11 @@ function App() {
                     onClick={() => {
                         if(!audioCtx) initAudioCtx();
 
-                        outputClip = new Clip(massAlias(speedupFactor, clipsEx), "mass-aliasing-output");
+                        let _outputClip = new Clip(massAlias(speedupFactor, clipsEx), "mass-aliasing-output"); 
+                        _outputClip.generateDownload();
+                        _outputClip.play();
 
-                        outputClip.play();
-                        outputClip.generateDownload();
-
+                        setOutputClip(_outputClip);
                         setOutputClipReady(true);
                     }}
                 >Mass Alias!</button>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -111,6 +111,15 @@ function App() {
                     onClick={() => {
                         if(!audioCtx) initAudioCtx();
 
+                        if(clipsEx.length == 0){
+                            Swal.fire({
+                                icon: 'info',
+                                text: 'I gotta have some clips! Drag and drop audio files onto the big yellow box :)'
+                            });
+
+                            return;
+                        }
+
                         let _outputClip = new Clip(massAlias(speedupFactor, clipsEx), "mass-aliasing-output"); 
                         _outputClip.generateDownload();
                         _outputClip.play();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import ClipList, { clipsEx, setClipsEx } from "./components/ClipList.jsx";
 import AudioFileDrop from "./components/AudioFileDrop.jsx";
 import PlaybackRateControl from "./components/PlaybackRateControl.jsx";
 import MasterVolumeControl from "./components/MasterVolumeControl.jsx";
+import Swal from "sweetalert2";
 
 export const AudioContext = window.AudioContext || window.webkitAudioContext;
 
@@ -122,6 +123,7 @@ function App() {
                 <button onClick={() => {
                     setClipsEx([]);
                     Clip.allClips = [];
+                    setOutputClipReady(false);
                 }}>
                     Clear all clips
                 </button>


### PR DESCRIPTION
Previously there was a bug where the save link would not update when you aliased a second, third, fourth, etc time. This was because `outputClip` was not hooked into React's state system. The only reason the blob linked worked the first time is I assume because the handler in the save link wasnt loaded until the component showed for the first time, which would be after the outputClip is set for the first time.

There is also now a sweetalert when you try to mass alias without any clips loaded.

Finally, the save button now disappears when you clear all clips.